### PR TITLE
Textsink: do not write through a symlink

### DIFF
--- a/lib/App/Igor/Sink.pm
+++ b/lib/App/Igor/Sink.pm
@@ -83,6 +83,9 @@ sub check {
 		} catch {
 			$changeneeded = 1;
 		};
+		if (-e $self->path && not S_ISREG($self->path->lstat->mode)) {
+			die ("File sink '@{[$self->path]}' for text output operation (e.g. template/copy/collection) already exists and is not a regular file");
+		}
 	} elsif ($type == App::Igor::Pipeline::Type::FILE) {
 		try {
 			$changeneeded = not (S_ISLNK($self->path->lstat->mode) && ($self->path->realpath eq $data->realpath));


### PR DESCRIPTION
When switching from a symlinked file to a "copy" target, igor used to
silently overwrite the file behind the symlink, which is unexpected.
Therefore, we now check that the file that the text is being emitted to
is a regular file.

Thanks to yushyin for reporting and testing.